### PR TITLE
Propagate errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -145,7 +145,7 @@ ShopifyToken.prototype.getAccessToken = function getAccessToken(shop, code, fn) 
     });
     response.on('end', function end() {
       if (status !== 200) {
-        return fn(new Error('status: ' + status + ', ' + body));
+        return fn(new Error('Failed to get Shopify access token, status: ' + status + ', ' + body));
       }
 
       try {

--- a/index.js
+++ b/index.js
@@ -139,19 +139,19 @@ ShopifyToken.prototype.getAccessToken = function getAccessToken(shop, code, fn) 
     var status = response.statusCode
       , body = '';
 
-    if (status !== 200) {
-      return fn(new Error('Invalid status code (' + status + ') returned'));
-    }
-
     response.setEncoding('utf8');
     response.on('data', function data(chunk) {
       body += chunk;
     });
     response.on('end', function end() {
+      if (status !== 200) {
+        return fn(new Error('status: ' + status + ', ' + body));
+      }
+
       try {
         body = JSON.parse(body);
       } catch (e) {
-        return fn(new Error('Failed to parse the response body'));
+        return fn(new Error('Failed to parse the response body (' + body + ')'));
       }
 
       fn(undefined, body.access_token);

--- a/index.js
+++ b/index.js
@@ -157,6 +157,7 @@ ShopifyToken.prototype.getAccessToken = function getAccessToken(shop, code, fn) 
       } catch (e) {
         error = new Error('Failed to parse the response body');
         error.responseBody = body;
+        error.statusCode = status;
         return fn(error);
       }
 

--- a/index.js
+++ b/index.js
@@ -144,14 +144,20 @@ ShopifyToken.prototype.getAccessToken = function getAccessToken(shop, code, fn) 
       body += chunk;
     });
     response.on('end', function end() {
+      var error;
       if (status !== 200) {
-        return fn(new Error('Failed to get Shopify access token, status: ' + status + ', ' + body));
+        error = new Error('Failed to get Shopify access token');
+        error.responseBody = body;
+        error.statusCode = status;
+        return fn(error);
       }
 
       try {
         body = JSON.parse(body);
       } catch (e) {
-        return fn(new Error('Failed to parse the response body (' + body + ')'));
+        error = new Error('Failed to parse the response body');
+        error.responseBody = body;
+        return fn(error);
       }
 
       fn(undefined, body.access_token);

--- a/test.js
+++ b/test.js
@@ -179,11 +179,13 @@ describe('shopify-token', function () {
     it('returns an error if response statusCode is not 200', function (done) {
       scope
       .post(pathname)
-      .reply(400, 'some error');
+      .reply(400, 'some error message from shopify');
 
       shopifyToken.getAccessToken(hostname, '123456', function (err, res) {
         expect(err).to.be.an.instanceof(Error);
-        expect(err.message).to.equal('Failed to get Shopify access token, status: 400, some error');
+        expect(err).to.have.property('message', 'Failed to get Shopify access token');
+        expect(err).to.have.property('responseBody', 'some error message from shopify');
+        expect(err).to.have.property('statusCode', 400);
         expect(res).to.equal(undefined);
         done();
       });
@@ -196,7 +198,8 @@ describe('shopify-token', function () {
 
       shopifyToken.getAccessToken(hostname, '123456', function (err, res) {
         expect(err).to.be.an.instanceof(Error);
-        expect(err.message).to.equal('Failed to parse the response body (<!DOCTYPE html><html><head></head><body></body></html>)');
+        expect(err).to.have.property('message', 'Failed to parse the response body');
+        expect(err).to.have.property('responseBody', '<!DOCTYPE html><html><head></head><body></body></html>');
         expect(res).to.equal(undefined);
         done();
       });

--- a/test.js
+++ b/test.js
@@ -183,7 +183,7 @@ describe('shopify-token', function () {
 
       shopifyToken.getAccessToken(hostname, '123456', function (err, res) {
         expect(err).to.be.an.instanceof(Error);
-        expect(err.message).to.equal('status: 400, some error');
+        expect(err.message).to.equal('Failed to get Shopify access token, status: 400, some error');
         expect(res).to.equal(undefined);
         done();
       });

--- a/test.js
+++ b/test.js
@@ -179,11 +179,11 @@ describe('shopify-token', function () {
     it('returns an error if response statusCode is not 200', function (done) {
       scope
       .post(pathname)
-      .reply(400);
+      .reply(400, 'some error');
 
       shopifyToken.getAccessToken(hostname, '123456', function (err, res) {
         expect(err).to.be.an.instanceof(Error);
-        expect(err.message).to.equal('Invalid status code (400) returned');
+        expect(err.message).to.equal('status: 400, some error');
         expect(res).to.equal(undefined);
         done();
       });
@@ -196,7 +196,7 @@ describe('shopify-token', function () {
 
       shopifyToken.getAccessToken(hostname, '123456', function (err, res) {
         expect(err).to.be.an.instanceof(Error);
-        expect(err.message).to.equal('Failed to parse the response body');
+        expect(err.message).to.equal('Failed to parse the response body (<!DOCTYPE html><html><head></head><body></body></html>)');
         expect(res).to.equal(undefined);
         done();
       });

--- a/test.js
+++ b/test.js
@@ -200,6 +200,7 @@ describe('shopify-token', function () {
         expect(err).to.be.an.instanceof(Error);
         expect(err).to.have.property('message', 'Failed to parse the response body');
         expect(err).to.have.property('responseBody', '<!DOCTYPE html><html><head></head><body></body></html>');
+        expect(err).to.have.property('statusCode', 200);
         expect(res).to.equal(undefined);
         done();
       });


### PR DESCRIPTION
Give callback a more detailed error message when failing to get an access token