### PR TITLE
Allow nonce to be overridden

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,20 +59,26 @@ function ShopifyToken(options) {
   this.apiKey = options.apiKey;
 }
 
+ShopifyToken.prototype.generateNonce = function() {
+  return crypto.randomBytes(16).toString('hex');
+};
+
 /**
  * Build the authorization URL.
  *
  * @param {String} shop The shop name
  * @param {Array|String} [scopes] The list of scopes
+ * @param {String} Random string (ideally persisted elsewhere) for comparison on callback
  * @return {String} The authorization URL
  * @public
  */
-ShopifyToken.prototype.generateAuthUrl = function generateAuthUrl(shop, scopes) {
-  scopes || (scopes = this.scopes);
+ShopifyToken.prototype.generateAuthUrl = function generateAuthUrl(shop, scopes, nonce) {
+  scopes = scopes || this.scopes;
+  nonce = nonce || this.generateNonce();
 
   var query = {
     scope: Array.isArray(scopes) ? scopes.join(',') : scopes,
-    state: crypto.randomBytes(16).toString('hex'),
+    state: nonce,
     redirect_uri: this.redirectUri,
     client_id: this.apiKey
   };

--- a/test.js
+++ b/test.js
@@ -55,6 +55,7 @@ describe('shopify-token', function () {
   describe('#generateAuthUrl', function () {
     it('builds the authorization URL', function () {
       var uri = shopifyToken.generateAuthUrl('qux');
+      var nonce = url.parse(uri, true).query.state;
 
       expect(uri).to.equal(url.format({
         pathname: '/admin/oauth/authorize',
@@ -62,15 +63,16 @@ describe('shopify-token', function () {
         protocol: 'https:',
         query: {
           scope: 'read_content',
-          state: url.parse(uri, true).query.state,
+          state: nonce,
           redirect_uri: 'bar',
           client_id: 'baz'
         }
       }));
+      expect(nonce).to.be.a('string').and.have.length(32);
     });
 
-    it('allows to override the default scopes', function () {
-      var uri = shopifyToken.generateAuthUrl('qux', 'read_themes,read_products');
+    it('allows to override the default scopes and nonce', function () {
+      var uri = shopifyToken.generateAuthUrl('qux', 'read_themes,read_products', 'somenonce');
 
       expect(uri).to.equal(url.format({
         pathname: '/admin/oauth/authorize',
@@ -78,7 +80,7 @@ describe('shopify-token', function () {
         protocol: 'https:',
         query: {
           scope: 'read_themes,read_products',
-          state: url.parse(uri, true).query.state,
+          state: 'somenonce',
           redirect_uri: 'bar',
           client_id: 'baz'
         }


### PR DESCRIPTION
The nonce is supposed to be persisted (or replicable) locally in order to verify it on OAuth completion. That means it needs to be possible to pass it in, rather than have it generated internally.

See https://help.shopify.com/api/guides/authentication/oauth:

> {nonce} - a randomly selected value provided by your application, which is unique for each authorization request. During the OAuth callback phase, your application must check that this value matches the one you provided during authorization. This mechanism is important for the security of your application.