### PR TITLE
Add `timeout` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ Creates a new `ShopifyToken` instance.
 - `scopes` - Optional - An array of strings or a comma-separated string that
   specifies the list of scopes e.g. `'read_content,read_themes'`. Defaults to
   `'read_content'`.
+- `timeout` - Optional - A number that specifies the milliseconds to wait for
+  the server to send a response to the HTTPS request initiated by the
+  `getAccessToken` method before aborting it. Defaults to 60000, or 1 minute.
 
 #### Return value
 
@@ -143,7 +146,7 @@ Exchanges the authorization code for a permanent access token.
   passed by Shopify in the confirmation redirect.
 - `fn(err, token)` - An error-first callback function which is called when the
   token has been exchanged or an error occurs. When the exchange fails, you can
-  read the HTTP response status code and body from the `statusCode` and
+  read the HTTPS response status code and body from the `statusCode` and
   `responseBody` properties which are added to the error object.
 
 #### Return value


### PR DESCRIPTION
This adds the ability to specify the milliseconds to wait for the server to send a response to the HTTPS request created in the `getAccessToken` method before aborting it.

Fixes #4.