### PR TITLE
Replace callback with Promise

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ node_js:
   - "6"
   - "5"
   - "4"
-  - "0.12"
-  - "0.10"
 script:
   - "npm run test-travis"
 after_script:

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ console.log(ok);
 // => true
 ```
 
-### `shopifyToken.getAccessToken(hostname, code, fn)`
+### `shopifyToken.getAccessToken(hostname, code)`
 
 Exchanges the authorization code for a permanent access token.
 
@@ -144,14 +144,13 @@ Exchanges the authorization code for a permanent access token.
   by Shopify in the confirmation redirect.
 - `code` - The authorization Code. You can get this from the `code` parameter
   passed by Shopify in the confirmation redirect.
-- `fn(err, token)` - An error-first callback function which is called when the
-  token has been exchanged or an error occurs. When the exchange fails, you can
-  read the HTTPS response status code and body from the `statusCode` and
-  `responseBody` properties which are added to the error object.
 
 #### Return value
 
-The `ShopifyToken` object.
+A `Promise` which gets resolved with the `token`. When the exchange fails, you can
+read the HTTPS response status code and body from the `statusCode` and
+`responseBody` properties which are added to the error object.
+
 
 #### Example
 
@@ -159,12 +158,12 @@ The `ShopifyToken` object.
 var code = '4d732838ad8c22cd1d2dd96f8a403fb7'
   , hostname = 'dolciumi.myshopify.com';
 
-shopifyToken.getAccessToken(hostname, code, function get(err, token) {
-  if (err) throw err;
-
+shopifyToken.getAccessToken(hostname, code).then(token => {
   console.log(token);
   // => f85632530bf277ec9ac6f649fc327f17
-});
+}).catch(err => {
+  throw err
+})
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -147,9 +147,7 @@ Exchanges the authorization code for a permanent access token.
 
 #### Return value
 
-A `Promise` which gets resolved with the `token`. When the exchange fails, you can
-read the HTTPS response status code and body from the `statusCode` and
-`responseBody` properties which are added to the error object.
+A `Promise` which gets resolved with the `token`. When the exchange fails, you can read the HTTPS response status code and body from the `statusCode` and `responseBody` properties which are added to the error object.
 
 
 #### Example
@@ -162,7 +160,7 @@ shopifyToken.getAccessToken(hostname, code).then(token => {
   console.log(token);
   // => f85632530bf277ec9ac6f649fc327f17
 }).catch(err => {
-  throw err
+  console.err(err)
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ Throws a `Error` exception if the required options are missing.
 #### Example
 
 ```js
-var ShopifyToken = require('shopify-token');
+const ShopifyToken = require('shopify-token');
 
-var shopifyToken = new ShopifyToken({
+const shopifyToken = new ShopifyToken({
   sharedSecret: '8ceb18e8ca581aee7cad1ddd3991610b',
   redirectUri: 'http://localhost:8080/callback',
   apiKey: 'e74d25b9a6f2b15f2836c954ea8c1711'
@@ -72,7 +72,7 @@ A string representing the nonce.
 #### Example
 
 ```js
-var nonce = shopifyToken.generateNonce();
+const nonce = shopifyToken.generateNonce();
 
 console.log(nonce);
 // => 212a8b839860d1aefb258aaffcdbd63f
@@ -97,7 +97,7 @@ A string representing the URL where the user should be redirected.
 #### Example
 
 ```js
-var url = shopifyToken.generateAuthUrl('dolciumi');
+const url = shopifyToken.generateAuthUrl('dolciumi');
 
 console.log(url);
 // => https://dolciumi.myshopify.com/admin/oauth/authorize?scope=read_content&state=7194ee27dd47ac9efb0ad04e93750e64&redirect_uri=http%3A%2F%2Flocalhost%3A8080%2Fcallback&client_id=e74d25b9a6f2b15f2836c954ea8c1711
@@ -120,7 +120,7 @@ validates the hmac parameter.
 #### Example
 
 ```js
-var ok = shopifyToken.verifyHmac({
+const ok = shopifyToken.verifyHmac({
   hmac: 'd1c59b480761bdabf7ee7eb2c09a3d84e71b1d37991bc2872bea8a4c43f8b2b3',
   signature: '184559898f5bbd1301606e7919c6e67f',
   state: 'b77827e928ee8eee614b5808d3276c8a',
@@ -153,7 +153,7 @@ A `Promise` which gets resolved with the `token`. When the exchange fails, you c
 #### Example
 
 ```js
-var code = '4d732838ad8c22cd1d2dd96f8a403fb7'
+const code = '4d732838ad8c22cd1d2dd96f8a403fb7'
   , hostname = 'dolciumi.myshopify.com';
 
 shopifyToken.getAccessToken(hostname, code).then(token => {

--- a/index.js
+++ b/index.js
@@ -175,7 +175,7 @@ ShopifyToken.prototype.getAccessToken = function getAccessToken(shop, code) {
           error = new Error('Failed to get Shopify access token');
           error.responseBody = body;
           error.statusCode = status;
-          reject(error);
+          return reject(error);
         }
 
         try {
@@ -184,7 +184,7 @@ ShopifyToken.prototype.getAccessToken = function getAccessToken(shop, code) {
           error = new Error('Failed to parse the response body');
           error.responseBody = body;
           error.statusCode = status;
-          reject(error);
+          return reject(error);
         }
 
         resolve(body.access_token);

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var crypto = require('crypto')
+const crypto = require('crypto')
   , https = require('https')
   , url = require('url');
 
@@ -83,7 +83,7 @@ ShopifyToken.prototype.generateNonce = function() {
 ShopifyToken.prototype.generateAuthUrl = function generateAuthUrl(shop, scopes, nonce) {
   scopes || (scopes = this.scopes);
 
-  var query = {
+  const query = {
     scope: Array.isArray(scopes) ? scopes.join(',') : scopes,
     state: nonce || this.generateNonce(),
     redirect_uri: this.redirectUri,
@@ -106,17 +106,17 @@ ShopifyToken.prototype.generateAuthUrl = function generateAuthUrl(shop, scopes, 
  * @public
  */
 ShopifyToken.prototype.verifyHmac = function verifyHmac(query) {
-  var pairs = Object.keys(query).filter(function filter(key) {
+  const pairs = Object.keys(query).filter(function filter(key) {
     return key !== 'signature' && key !== 'hmac';
   }).map(function map(key) {
-    var value = query[key];
+    const value = query[key];
 
     return typeof value === 'string'
       ? encodeKey(key) + '=' + encodeValue(value)
       : '';
   }).sort();
 
-  var digest = crypto.createHmac('sha256', this.sharedSecret)
+  const digest = crypto.createHmac('sha256', this.sharedSecret)
     .update(pairs.join('&'))
     .digest('hex');
 
@@ -128,18 +128,18 @@ ShopifyToken.prototype.verifyHmac = function verifyHmac(query) {
  *
  * @param {String} shop The hostname of the shop, e.g. foo.myshopify.com
  * @param {String} code The authorization code
- * @return {Promise} token
+ * @return {Promise} Promise which is fulfilled with the token.
  * @public
  */
 ShopifyToken.prototype.getAccessToken = function getAccessToken(shop, code) {
   return new Promise((resolve, reject) => {
-    var data = JSON.stringify({
+    const data = JSON.stringify({
       client_secret: this.sharedSecret,
       client_id: this.apiKey,
       code: code
     });
 
-    var request = https.request({
+    const request = https.request({
       headers: {
         'Content-Length': Buffer.byteLength(data),
         'Content-Type': 'application/json',
@@ -150,14 +150,14 @@ ShopifyToken.prototype.getAccessToken = function getAccessToken(shop, code) {
       method: 'POST'
     });
 
-    var timer = setTimeout(function timeout() {
+    let timer = setTimeout(function timeout() {
       request.abort();
       timer = null;
       reject(new Error('Request timed out'))
     }, this.timeout);
 
     request.on('response', function reply(response) {
-      var status = response.statusCode
+      let status = response.statusCode
         , body = '';
 
       response.setEncoding('utf8');
@@ -165,7 +165,7 @@ ShopifyToken.prototype.getAccessToken = function getAccessToken(shop, code) {
         body += chunk;
       });
       response.on('end', function end() {
-        var error;
+        let error;
 
         if (!timer) return;
 

--- a/index.js
+++ b/index.js
@@ -128,79 +128,78 @@ ShopifyToken.prototype.verifyHmac = function verifyHmac(query) {
  *
  * @param {String} shop The hostname of the shop, e.g. foo.myshopify.com
  * @param {String} code The authorization code
- * @param {Function} fn Callback
- * @return {ShopifyToken} this
+ * @return {Promise} token
  * @public
  */
-ShopifyToken.prototype.getAccessToken = function getAccessToken(shop, code, fn) {
-  var data = JSON.stringify({
-    client_secret: this.sharedSecret,
-    client_id: this.apiKey,
-    code: code
-  });
-
-  var request = https.request({
-    headers: {
-      'Content-Length': Buffer.byteLength(data),
-      'Content-Type': 'application/json',
-      'Accept': 'application/json'
-    },
-    path: '/admin/oauth/access_token',
-    hostname: shop,
-    method: 'POST'
-  });
-
-  var timer = setTimeout(function timeout() {
-    request.abort();
-    timer = null;
-    fn(new Error('Request timed out'));
-  }, this.timeout);
-
-  request.on('response', function reply(response) {
-    var status = response.statusCode
-      , body = '';
-
-    response.setEncoding('utf8');
-    response.on('data', function data(chunk) {
-      body += chunk;
+ShopifyToken.prototype.getAccessToken = function getAccessToken(shop, code) {
+  return new Promise((resolve, reject) => {
+    var data = JSON.stringify({
+      client_secret: this.sharedSecret,
+      client_id: this.apiKey,
+      code: code
     });
-    response.on('end', function end() {
-      var error;
 
+    var request = https.request({
+      headers: {
+        'Content-Length': Buffer.byteLength(data),
+        'Content-Type': 'application/json',
+        'Accept': 'application/json'
+      },
+      path: '/admin/oauth/access_token',
+      hostname: shop,
+      method: 'POST'
+    });
+
+    var timer = setTimeout(function timeout() {
+      request.abort();
+      timer = null;
+      reject(new Error('Request timed out'))
+    }, this.timeout);
+
+    request.on('response', function reply(response) {
+      var status = response.statusCode
+        , body = '';
+
+      response.setEncoding('utf8');
+      response.on('data', function data(chunk) {
+        body += chunk;
+      });
+      response.on('end', function end() {
+        var error;
+
+        if (!timer) return;
+
+        clearTimeout(timer);
+
+        if (status !== 200) {
+          error = new Error('Failed to get Shopify access token');
+          error.responseBody = body;
+          error.statusCode = status;
+          reject(error);
+        }
+
+        try {
+          body = JSON.parse(body);
+        } catch (e) {
+          error = new Error('Failed to parse the response body');
+          error.responseBody = body;
+          error.statusCode = status;
+          reject(error);
+        }
+
+        resolve(body.access_token);
+      });
+    });
+
+    request.on('error', function error(err) {
       if (!timer) return;
 
       clearTimeout(timer);
-
-      if (status !== 200) {
-        error = new Error('Failed to get Shopify access token');
-        error.responseBody = body;
-        error.statusCode = status;
-        return fn(error);
-      }
-
-      try {
-        body = JSON.parse(body);
-      } catch (e) {
-        error = new Error('Failed to parse the response body');
-        error.responseBody = body;
-        error.statusCode = status;
-        return fn(error);
-      }
-
-      fn(undefined, body.access_token);
+      reject(err);
     });
-  });
 
-  request.on('error', function error(err) {
-    if (!timer) return;
-
-    clearTimeout(timer);
-    fn(err);
-  });
-
-  request.end(data);
-
-  return this;
+    request.end(data);
+  })
 };
 
 module.exports = ShopifyToken;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shopify-token",
-  "version": "3.0.0",
+  "version": "2.1.0",
   "description": "Get an OAuth 2.0 access token for the Shopify API with ease",
   "homepage": "https://github.com/lpinca/shopify-token",
   "bugs": "https://github.com/lpinca/shopify-token/issues",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shopify-token",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "description": "Get an OAuth 2.0 access token for the Shopify API with ease",
   "homepage": "https://github.com/lpinca/shopify-token",
   "bugs": "https://github.com/lpinca/shopify-token/issues",

--- a/test.js
+++ b/test.js
@@ -196,12 +196,13 @@ describe('shopify-token', function () {
         })
         .reply(200, { access_token: token });
 
-      shopifyToken.getAccessToken(hostname, code, function (err, res) {
-        if (err) return done(err);
-
+      shopifyToken.getAccessToken(hostname, code).then(function (res) {
+        console.log('123')
         expect(res).to.equal(token);
         done();
-      });
+      }).catch(function (err) {
+        console.log(err)
+      })
     });
 
     it('returns an error if the request fails', function (done) {
@@ -211,12 +212,12 @@ describe('shopify-token', function () {
         .post(pathname)
         .replyWithError(message);
 
-      shopifyToken.getAccessToken(hostname, '123456', function (err, res) {
+      shopifyToken.getAccessToken(hostname, '123456').catch(function (err) {
         expect(err).to.be.an.instanceof(Error);
         expect(err.message).to.equal(message);
-        expect(res).to.equal(undefined);
         done();
-      });
+      })
+
     });
 
     it('returns an error when timeout expires (headers)', function (done) {
@@ -232,12 +233,11 @@ describe('shopify-token', function () {
         .delay({ head: 200 })
         .reply(200, {});
 
-      shopifyToken.getAccessToken(hostname, '123456', function (err, res) {
+      shopifyToken.getAccessToken(hostname, '123456').catch(function (err) {
         expect(err).to.be.an.instanceof(Error);
         expect(err.message).to.equal('Request timed out');
-        expect(res).to.equal(undefined);
         done();
-      });
+      })
     });
 
     it('returns an error when timeout expires (body)', function (done) {
@@ -253,12 +253,12 @@ describe('shopify-token', function () {
         .delay({ body: 200 })
         .reply(200, {});
 
-      shopifyToken.getAccessToken(hostname, '123456', function (err, res) {
+      shopifyToken.getAccessToken(hostname, '123456').catch(function (err) {
         expect(err).to.be.an.instanceof(Error);
         expect(err.message).to.equal('Request timed out');
-        expect(res).to.equal(undefined);
         done();
       });
+
     });
 
     it('returns an error when timeout expires (connection)', function (done) {
@@ -275,10 +275,9 @@ describe('shopify-token', function () {
       // issues a non-routable IP address is used here instead of `nock`. See
       // https://tools.ietf.org/html/rfc5737#section-3
       //
-      shopifyToken.getAccessToken('192.0.2.1', '123456', function (err, res) {
+      shopifyToken.getAccessToken('192.0.2.1', '123456').catch(function (err) {
         expect(err).to.be.an.instanceof(Error);
         expect(err.message).to.equal('Request timed out');
-        expect(res).to.equal(undefined);
         done();
       });
     });
@@ -290,12 +289,11 @@ describe('shopify-token', function () {
         .post(pathname)
         .reply(400, body);
 
-      shopifyToken.getAccessToken(hostname, '123456', function (err, res) {
+      shopifyToken.getAccessToken(hostname, '123456').catch(function (err) {
         expect(err).to.be.an.instanceof(Error);
         expect(err).to.have.property('message', 'Failed to get Shopify access token');
         expect(err).to.have.property('responseBody', body);
         expect(err).to.have.property('statusCode', 400);
-        expect(res).to.equal(undefined);
         done();
       });
     });
@@ -307,12 +305,11 @@ describe('shopify-token', function () {
         .post(pathname)
         .reply(200, body);
 
-      shopifyToken.getAccessToken(hostname, '123456', function (err, res) {
+      shopifyToken.getAccessToken(hostname, '123456').catch(function (err) {
         expect(err).to.be.an.instanceof(Error);
         expect(err).to.have.property('message', 'Failed to parse the response body');
         expect(err).to.have.property('responseBody', body);
         expect(err).to.have.property('statusCode', 200);
-        expect(res).to.equal(undefined);
         done();
       });
     });


### PR DESCRIPTION
A more modern approach, so it's possible to use Async/Await in the future. Promises are supported since Node 0.12.0, which is no longer maintained. So it's save to depend on it. The only thing here is that I use an Arrow function for context binding. They are implemented since 5.11.0, but I think we shouldn't hold on that old Node versions either.