### PR TITLE
Add support for online access mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ Creates a new `ShopifyToken` instance.
   the server to send a response to the HTTPS request initiated by the
   `getAccessToken` method before aborting it. Defaults to 60000, or 1 minute.
 - `accessMode` - Optional - A string representing the [API access
-  modes][api-access-mode]. Set this parameter to `'per-user'` to receive an
-  access token that respects the user's permission level when making API
-  requests (called online access). This is strongly recommended for embedded
-  apps.
+  modes][api-access-mode]. Set this option to `'per-user'` to receive an access
+  token that respects the user's permission level when making API requests
+  (called online access). This is strongly recommended for embedded apps.
+  Defaults to offline access mode.
 
 #### Return value
 
@@ -95,7 +95,8 @@ Builds and returns the authorization URL where you should redirect the user.
 - `nonce` - An optional string representing the nonce. If not provided it will
   be generated automatically.
 - `accessMode` - An optional string dictating the API access mode. If not
-  provided it will use offline mode.
+  provided the access mode defined by the `accessMode` constructor option will
+  be used.
 
 #### Return value
 

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 [![Coverage Status][coverage-shopify-token-badge]][coverage-shopify-token]
 
 This module helps you retrieve an access token for the Shopify REST API. It
-provides some convenience methods that can be used when implementing the
-[OAuth 2.0 flow][shopify-oauth-doc]. No assumptions are made about your
-server-side architecture, allowing the module to easily adapt to any setup.
+provides some convenience methods that can be used when implementing the [OAuth
+2.0 flow][shopify-oauth-doc]. No assumptions are made about your server-side
+architecture, allowing the module to easily adapt to any setup.
 
 ## Install
 
@@ -40,7 +40,11 @@ Creates a new `ShopifyToken` instance.
 - `timeout` - Optional - A number that specifies the milliseconds to wait for
   the server to send a response to the HTTPS request initiated by the
   `getAccessToken` method before aborting it. Defaults to 60000, or 1 minute.
-- `access_mode` - Optional - A string representing [API access modes](https://help.shopify.com/en/api/getting-started/authentication/oauth/api-access-modes). Set this parameter to `per-user` to receive an access token that respects the user’s permission level when making API requests (called online access). This is strongly recommended for embedded apps.
+- `accessMode` - Optional - A string representing the [API access
+  modes][api-access-mode]. Set this parameter to `'per-user'` to receive an
+  access token that respects the user's permission level when making API
+  requests (called online access). This is strongly recommended for embedded
+  apps.
 
 #### Return value
 
@@ -79,7 +83,7 @@ console.log(nonce);
 // => 212a8b839860d1aefb258aaffcdbd63f
 ```
 
-### `shopifyToken.generateAuthUrl(shop[, scopes[, nonce[, access_mode]]])`
+### `shopifyToken.generateAuthUrl(shop[, scopes[, nonce[, accessMode]]])`
 
 Builds and returns the authorization URL where you should redirect the user.
 
@@ -90,7 +94,8 @@ Builds and returns the authorization URL where you should redirect the user.
   the list of scopes. This allows you to override the default scopes.
 - `nonce` - An optional string representing the nonce. If not provided it will
   be generated automatically.
-- `access_mode` - An optional string dictating the API access mode. If not provided it will use offline mode.
+- `accessMode` - An optional string dictating the API access mode. If not
+  provided it will use offline mode.
 
 #### Return value
 
@@ -137,42 +142,51 @@ console.log(ok);
 
 ### `shopifyToken.getAccessToken(hostname, code)`
 
-Exchanges the authorization code for a permanent access token. 
+Exchanges the authorization code for a permanent access token.
 
 #### Arguments
 
-- `hostname` - A string that specifies the hostname of the user's shop.
-  e.g. `foo.myshopify.com`. You can get this from the `shop` parameter passed
-  by Shopify in the confirmation redirect.
+- `hostname` - A string that specifies the hostname of the user's shop. e.g.
+  `foo.myshopify.com`. You can get this from the `shop` parameter passed by
+  Shopify in the confirmation redirect.
 - `code` - The authorization Code. You can get this from the `code` parameter
   passed by Shopify in the confirmation redirect.
 
 #### Return value
 
-A `Promise` which gets resolved with the `token payload` object. When the exchange fails, you
-can read the HTTPS response status code and body from the `statusCode` and
-`responseBody` properties which are added to the error object.
+A `Promise` which gets resolved with an access token and additional data. When
+the exchange fails, you can read the HTTPS response status code and body from
+the `statusCode` and `responseBody` properties which are added to the error
+object.
 
 #### Example
 
 ```js
-const code = '4d732838ad8c22cd1d2dd96f8a403fb7'
+const code = '4d732838ad8c22cd1d2dd96f8a403fb7';
 const hostname = 'dolciumi.myshopify.com';
 
-shopifyToken.getAccessToken(hostname, code).then((data) => {
-  console.log(data.token);
-  // => f85632530bf277ec9ac6f649fc327f17
-}).catch((err) => console.err(err));
+shopifyToken
+  .getAccessToken(hostname, code)
+  .then(data => {
+    console.log(data);
+    // => { access_token: 'f85632530bf277ec9ac6f649fc327f17', scope: 'read_content' }
+  })
+  .catch(err => console.err(err));
 ```
 
 ## License
 
 [MIT](LICENSE)
 
+[api-access-mode]:
+  https://help.shopify.com/en/api/getting-started/authentication/oauth/api-access-modes
 [npm-shopify-token-badge]: https://img.shields.io/npm/v/shopify-token.svg
 [npm-shopify-token]: https://www.npmjs.com/package/shopify-token
-[travis-shopify-token-badge]: https://img.shields.io/travis/lpinca/shopify-token/master.svg
+[travis-shopify-token-badge]:
+  https://img.shields.io/travis/lpinca/shopify-token/master.svg
 [travis-shopify-token]: https://travis-ci.org/lpinca/shopify-token
-[coverage-shopify-token-badge]: https://img.shields.io/coveralls/lpinca/shopify-token/master.svg
-[coverage-shopify-token]: https://coveralls.io/r/lpinca/shopify-token?branch=master
+[coverage-shopify-token-badge]:
+  https://img.shields.io/coveralls/lpinca/shopify-token/master.svg
+[coverage-shopify-token]:
+  https://coveralls.io/r/lpinca/shopify-token?branch=master
 [shopify-oauth-doc]: https://help.shopify.com/api/guides/authentication/oauth

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Creates a new `ShopifyToken` instance.
 - `timeout` - Optional - A number that specifies the milliseconds to wait for
   the server to send a response to the HTTPS request initiated by the
   `getAccessToken` method before aborting it. Defaults to 60000, or 1 minute.
-- `access_mode` - Optional - A string representing [API access modes](https://help.shopify.com/en/api/getting-started/authentication/oauth/api-access-modes), `'online'` or `'offline'`.
+- `access_mode` - Optional - A string representing [API access modes](https://help.shopify.com/en/api/getting-started/authentication/oauth/api-access-modes). Set this parameter to `per-user` to receive an access token that respects the user’s permission level when making API requests (called online access). This is strongly recommended for embedded apps.
 
 #### Return value
 
@@ -145,7 +145,7 @@ Exchanges the authorization code for a permanent access token.
   by Shopify in the confirmation redirect.
 - `code` - The authorization Code. You can get this from the `code` parameter
   passed by Shopify in the confirmation redirect.
-- `shouldReturnAllData` - Optional - A boolean with a default of `false` which only returns **access_token**. Setting this to true will return the full payload which is helpful when access_mode is set to online.  
+- `shouldReturnAllData` - Optional - A boolean with a default of `false` which only returns **access_token**. Setting this to true will return the full payload which is helpful when access_mode is set to `per-user`.  
 
 #### Return value
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ console.log(nonce);
 // => 212a8b839860d1aefb258aaffcdbd63f
 ```
 
-### `shopifyToken.generateAuthUrl(shop[, scopes[, nonce]])`
+### `shopifyToken.generateAuthUrl(shop[, scopes[, nonce[, access_mode]]])`
 
 Builds and returns the authorization URL where you should redirect the user.
 
@@ -90,6 +90,7 @@ Builds and returns the authorization URL where you should redirect the user.
   the list of scopes. This allows you to override the default scopes.
 - `nonce` - An optional string representing the nonce. If not provided it will
   be generated automatically.
+- `access_mode` - An optional string dictating the API access mode. If not provided it will use offline mode.
 
 #### Return value
 
@@ -136,7 +137,7 @@ console.log(ok);
 
 ### `shopifyToken.getAccessToken(hostname, code)`
 
-Exchanges the authorization code for a permanent access token.
+Exchanges the authorization code for a permanent access token. 
 
 #### Arguments
 
@@ -145,11 +146,10 @@ Exchanges the authorization code for a permanent access token.
   by Shopify in the confirmation redirect.
 - `code` - The authorization Code. You can get this from the `code` parameter
   passed by Shopify in the confirmation redirect.
-- `shouldReturnAllData` - Optional - A boolean with a default of `false` which only returns **access_token**. Setting this to true will return the full payload which is helpful when access_mode is set to `per-user`.  
 
 #### Return value
 
-A `Promise` which gets resolved with the `token`. When the exchange fails, you
+A `Promise` which gets resolved with the `token payload` object. When the exchange fails, you
 can read the HTTPS response status code and body from the `statusCode` and
 `responseBody` properties which are added to the error object.
 
@@ -159,8 +159,8 @@ can read the HTTPS response status code and body from the `statusCode` and
 const code = '4d732838ad8c22cd1d2dd96f8a403fb7'
 const hostname = 'dolciumi.myshopify.com';
 
-shopifyToken.getAccessToken(hostname, code).then((token) => {
-  console.log(token);
+shopifyToken.getAccessToken(hostname, code).then((data) => {
+  console.log(data.token);
   // => f85632530bf277ec9ac6f649fc327f17
 }).catch((err) => console.err(err));
 ```

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Creates a new `ShopifyToken` instance.
 - `timeout` - Optional - A number that specifies the milliseconds to wait for
   the server to send a response to the HTTPS request initiated by the
   `getAccessToken` method before aborting it. Defaults to 60000, or 1 minute.
+- `access_mode` - Optional - A string representing [API access modes](https://help.shopify.com/en/api/getting-started/authentication/oauth/api-access-modes), `'online'` or `'offline'`.
 
 #### Return value
 
@@ -144,6 +145,7 @@ Exchanges the authorization code for a permanent access token.
   by Shopify in the confirmation redirect.
 - `code` - The authorization Code. You can get this from the `code` parameter
   passed by Shopify in the confirmation redirect.
+- `shouldReturnAllData` - Optional - A boolean with a default of `false` which only returns **access_token**. Setting this to true will return the full payload which is helpful when access_mode is set to online.  
 
 #### Return value
 

--- a/example/index.js
+++ b/example/index.js
@@ -52,7 +52,8 @@ app.get('/callback', (req, res) => {
   // Exchange the authorization code for a permanent access token.
   //
   shopifyToken.getAccessToken(req.query.shop, req.query.code)
-    .then((token) => {
+    .then((data) => {
+      const token = data.access_token;
       console.log(token);
 
       req.session.token = token;

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ class ShopifyToken {
    * @param {String} options.sharedSecret The Shared Secret for the app
    * @param {Array|String} [options.scopes] The list of scopes
    * @param {String} options.apiKey The API Key for the app
-   * @param {String} options.access_mode The API access mode
+   * @param {String} [options.accessMode] The API access mode
    * @param {Number} [options.timeout] The request timeout
    */
   constructor(options) {
@@ -49,12 +49,12 @@ class ShopifyToken {
       throw new Error('Missing or invalid options');
     }
 
+    this.accessMode = 'accessMode' in options ? options.accessMode : '';
     this.scopes = 'scopes' in options ? options.scopes : 'read_content';
     this.timeout = 'timeout' in options ? options.timeout : 60000;
     this.sharedSecret = options.sharedSecret;
     this.redirectUri = options.redirectUri;
     this.apiKey = options.apiKey;
-    this.access_mode = options.access_mode || '';
   }
 
   /**
@@ -73,21 +73,24 @@ class ShopifyToken {
    * @param {String} shop The shop name
    * @param {Array|String} [scopes] The list of scopes
    * @param {String} [nonce] The nonce
-   * @param {String} [access_mode] The API access_mode 
+   * @param {String} [accessMode] The API access mode
    * @return {String} The authorization URL
    * @public
    */
-  generateAuthUrl(shop, scopes, nonce, access_mode) {
+  generateAuthUrl(shop, scopes, nonce, accessMode) {
     scopes || (scopes = this.scopes);
-    access_mode || (access_mode = this.access_mode);
+    accessMode || (accessMode = this.accessMode);
 
     const query = {
       scope: Array.isArray(scopes) ? scopes.join(',') : scopes,
       state: nonce || this.generateNonce(),
       redirect_uri: this.redirectUri,
-      client_id: this.apiKey,
-      'grant_options[]': access_mode
+      client_id: this.apiKey
     };
+
+    if (accessMode) {
+      query['grant_options[]'] = accessMode;
+    }
 
     return url.format({
       pathname: '/admin/oauth/authorize',
@@ -184,7 +187,7 @@ class ShopifyToken {
             error.statusCode = status;
             return reject(error);
           }
-          
+
           resolve(body);
         });
       });

--- a/index.js
+++ b/index.js
@@ -73,18 +73,20 @@ class ShopifyToken {
    * @param {String} shop The shop name
    * @param {Array|String} [scopes] The list of scopes
    * @param {String} [nonce] The nonce
+   * @param {String} [access_mode] The API access_mode 
    * @return {String} The authorization URL
    * @public
    */
-  generateAuthUrl(shop, scopes, nonce) {
+  generateAuthUrl(shop, scopes, nonce, access_mode) {
     scopes || (scopes = this.scopes);
+    access_mode || (access_mode = this.access_mode);
 
     const query = {
       scope: Array.isArray(scopes) ? scopes.join(',') : scopes,
       state: nonce || this.generateNonce(),
       redirect_uri: this.redirectUri,
       client_id: this.apiKey,
-      'grant_options[]': this.access_mode
+      'grant_options[]': access_mode
     };
 
     return url.format({
@@ -126,11 +128,10 @@ class ShopifyToken {
    *
    * @param {String} shop The hostname of the shop, e.g. foo.myshopify.com
    * @param {String} code The authorization code
-   * @param {Boolean} shouldReturnAllData Should the full payload be returned or only access_token
    * @return {Promise} Promise which is fulfilled with the token
    * @public
    */
-  getAccessToken(shop, code, shouldReturnAllData = false) {
+  getAccessToken(shop, code) {
     return new Promise((resolve, reject) => {
       const data = JSON.stringify({
         client_secret: this.sharedSecret,
@@ -184,8 +185,7 @@ class ShopifyToken {
             return reject(error);
           }
           
-          const tokenData = shouldReturnAllData ? body : body.access_token;
-          resolve(tokenData);
+          resolve(body);
         });
       });
 

--- a/index.js
+++ b/index.js
@@ -84,7 +84,7 @@ class ShopifyToken {
       state: nonce || this.generateNonce(),
       redirect_uri: this.redirectUri,
       client_id: this.apiKey,
-      'grant_options[]': this.access_mode === 'online' ? 'per-user' : ''
+      'grant_options[]': this.access_mode
     };
 
     return url.format({

--- a/index.js
+++ b/index.js
@@ -131,7 +131,8 @@ class ShopifyToken {
    *
    * @param {String} shop The hostname of the shop, e.g. foo.myshopify.com
    * @param {String} code The authorization code
-   * @return {Promise} Promise which is fulfilled with the token
+   * @return {Promise} Promise which is fulfilled with an access token and
+   *     additional data
    * @public
    */
   getAccessToken(shop, code) {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -11,7 +11,7 @@ declare namespace ShopifyToken {
     // The request timeout
     timeout?: number;
     // API access mode
-    access_mode?: string;
+    accessMode?: string;
   }
 }
 
@@ -24,7 +24,7 @@ declare class ShopifyToken {
    * @param {String} options.sharedSecret The Shared Secret for the app
    * @param {Array|String} [options.scopes] The list of scopes
    * @param {String} options.apiKey The API Key for the app
-   * @param {String} options.access_mode The API access mode
+   * @param {String} [options.accessMode] The API access mode
    * @param {Number} [options.timeout] The request timeout
    */
   constructor(options: ShopifyToken.ShopifyTokenOptions);
@@ -41,11 +41,11 @@ declare class ShopifyToken {
    * @param {String} shop The shop name
    * @param {Array|String} [scopes] The list of scopes
    * @param {String} [nonce] The nonce
-   * @param {String} [access_mode] The API access_mode
+   * @param {String} [accessMode] The API access mode
    * @return {String} The authorization URL
    * @public
    */
-  generateAuthUrl(shop: string, scopes?: string | string[], nonce?: string, access_mode?: string): string;
+  generateAuthUrl(shop: string, scopes?: string | string[], nonce?: string, accessMode?: string): string;
   /**
    * Verify the hmac returned by Shopify.
    *
@@ -59,7 +59,8 @@ declare class ShopifyToken {
    *
    * @param {String} shop The hostname of the shop, e.g. foo.myshopify.com
    * @param {String} code The authorization code
-   * @return {Promise} Promise which is fulfilled with the token data object
+   * @return {Promise} Promise which is fulfilled with an access token and
+   *     additional data
    * @public
    */
   getAccessToken(shop: string, code: string): Promise<object>;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -10,6 +10,8 @@ declare namespace ShopifyToken {
     scopes?: string | string[];
     // The request timeout
     timeout?: number;
+    // API access mode
+    access_mode?: string;
   }
 }
 
@@ -22,6 +24,7 @@ declare class ShopifyToken {
    * @param {String} options.sharedSecret The Shared Secret for the app
    * @param {Array|String} [options.scopes] The list of scopes
    * @param {String} options.apiKey The API Key for the app
+   * @param {String} options.access_mode The API access mode
    * @param {Number} [options.timeout] The request timeout
    */
   constructor(options: ShopifyToken.ShopifyTokenOptions);
@@ -55,10 +58,11 @@ declare class ShopifyToken {
    *
    * @param {String} shop The hostname of the shop, e.g. foo.myshopify.com
    * @param {String} code The authorization code
+   * @param {Boolean} shouldReturnAllData Should the full payload be returned or only access_token
    * @return {Promise} Promise which is fulfilled with the token
    * @public
    */
-  getAccessToken(shop: string, code: string): Promise<string>;
+  getAccessToken(shop: string, code: string, shouldReturnAllData: boolean): Promise<string>;
 }
 
 export = ShopifyToken;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -41,10 +41,11 @@ declare class ShopifyToken {
    * @param {String} shop The shop name
    * @param {Array|String} [scopes] The list of scopes
    * @param {String} [nonce] The nonce
+   * @param {String} [access_mode] The API access_mode
    * @return {String} The authorization URL
    * @public
    */
-  generateAuthUrl(shop: string, scopes?: string | string[], nonce?: string): string;
+  generateAuthUrl(shop: string, scopes?: string | string[], nonce?: string, access_mode?: string): string;
   /**
    * Verify the hmac returned by Shopify.
    *
@@ -58,11 +59,10 @@ declare class ShopifyToken {
    *
    * @param {String} shop The hostname of the shop, e.g. foo.myshopify.com
    * @param {String} code The authorization code
-   * @param {Boolean} shouldReturnAllData Should the full payload be returned or only access_token
-   * @return {Promise} Promise which is fulfilled with the token
+   * @return {Promise} Promise which is fulfilled with the token data object
    * @public
    */
-  getAccessToken(shop: string, code: string, shouldReturnAllData: boolean): Promise<string>;
+  getAccessToken(shop: string, code: string): Promise<object>;
 }
 
 export = ShopifyToken;


### PR DESCRIPTION
Fixes #15 

This PR adds support for API access modes such as online or offline through the `grant_options[]` parameter.

See more: https://help.shopify.com/en/api/getting-started/authentication/oauth/api-access-modes
https://help.shopify.com/en/api/getting-started/authentication/oauth/#update-oauth-scopes

## TODO
- [ ] Add test cases. Not very good at this. Will investigate.