### PR TITLE
Add support for custom shopify domains

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,7 +94,7 @@ class ShopifyToken {
 
     return url.format({
       pathname: '/admin/oauth/authorize',
-      hostname: shop.endsWith('.myshopify.com') ? shop : `${shop}.myshopify.com`,
+      hostname: shop.split(".").length > 1 ? shop : `${shop}.myshopify.com`,
       protocol: 'https:',
       query
     });


### PR DESCRIPTION
Right now, it doesn't generate auth url for custom domains like xyz.com or demo.xyz.com. Pushed the change to cover those cases.