### PR TITLE
Used timing-safe-equal library to handle timingSafeEqual missing in crypto object for browser

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 const crypto = require('crypto');
 const https = require('https');
 const url = require('url');
+const timingSafeEqual = require('timing-safe-equal');
 
 /**
  * Encode a string by replacing each instance of the `&` and `%` characters
@@ -130,7 +131,7 @@ class ShopifyToken {
       .update(pairs.join('&'))
       .digest();
 
-    return crypto.timingSafeEqual(digest, Buffer.from(query.hmac, 'hex'));
+    return timingSafeEqual(digest, Buffer.from(query.hmac, 'hex'));
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -31,5 +31,8 @@
     "mocha": "^8.1.3",
     "nock": "^13.0.4",
     "pre-commit": "^1.2.2"
+  },
+  "dependencies": {
+    "timing-safe-equal": "github:crypto-browserify/timing-safe-equal"
   }
 }


### PR DESCRIPTION
Hi team,

Kudos to you all for such an amazing library.
I am trying to use the library with the frontend (Ionic 5/ Vue 3). Here I am using most of the methods except the getting access token for the OAuth 2.0 flow.
It works smoothly for all cases as of now except the verifyHmac() method as timingSafeEqual is not found on the crypto object for the browser.
I have added [timing-safe-equal](https://github.com/crypto-browserify/timing-safe-equal) library that uses the crypto object is available uses the custom code to handle it. We can also add the same code to our repository as it is an MIT license code, but it will be something we have to maintain further. (Though I am open to create another PR if needed)